### PR TITLE
addressing std2018 issues

### DIFF
--- a/src/automaton_m.f90
+++ b/src/automaton_m.f90
@@ -336,8 +336,8 @@ contains
       use :: segment_disjoin_m
       implicit none
       class(automaton_t) :: self
-      type(nlist_t), pointer :: p, q
-      integer(int32) :: i, j, k 
+      type(nlist_t), pointer :: p
+      integer(int32) :: i, j
       type(priority_queue_t) :: queue
       type(segment_t), allocatable :: seg_list(:)
       integer :: num
@@ -653,10 +653,8 @@ contains
       class(automaton_t) :: self
       type(NFA_state_set_t), target :: initial_state
       type(D_state_t), pointer :: t
-      type(D_list_t), pointer :: x, ptr
+      type(D_list_t), pointer :: x
       type(D_slist_t), pointer :: p
-
-      integer :: j 
 
       t => null()
       x => null()
@@ -738,7 +736,7 @@ contains
       type(D_state_t), pointer :: state
 
       integer(int32) :: start, next
-      integer(int32) :: max_match, i, count
+      integer(int32) :: max_match, i
 
       str = str_arg
 
@@ -844,7 +842,7 @@ contains
    subroutine print_nfa(self)
       implicit none
       class(automaton_t) :: self 
-      integer :: i, j
+      integer :: i
       type(nlist_t), pointer :: p
       character(:), allocatable :: cache
 
@@ -892,7 +890,6 @@ contains
       class(automaton_t) :: self
       type(D_slist_t), pointer :: l
       integer(int32) :: i, j
-      character(1) :: c_Accepted
 
       write(stderr,*) "--- PRINT DFA---"
 

--- a/src/syntax_tree_m.f90
+++ b/src/syntax_tree_m.f90
@@ -366,10 +366,10 @@ contains
       implicit none
       type(tape_t), intent(inout) :: tape
       type(tree_t), pointer, intent(in) :: ptr
-      type(tree_t), pointer :: tree, tmp
+      type(tree_t), pointer :: tree
 
       character(:), allocatable :: buf
-      integer(int32) :: arg(2), ios, min, max, count, i
+      integer(int32) :: arg(2), ios, min, max, count
 
       buf = ''
       arg(:) = 0
@@ -509,7 +509,7 @@ contains
       type(segment_t), allocatable :: seglist(:)
 
       character(:), allocatable :: buf
-      integer :: siz, count_hyphen, i, inext, iend, j
+      integer :: siz, i, inext, iend, j
       logical :: inverted   
    
       tree => null()
@@ -717,11 +717,13 @@ contains
       implicit none
       type(segment_t), intent(inout), allocatable :: list(:)
 
-      logical :: unicode(UTF8_CODE_MIN:UTF8_CODE_MAX)
-      logical :: inverted(UTF8_CODE_MIN-1:UTF8_CODE_MAX+1)
+      logical, allocatable :: unicode(:)
+      logical, allocatable :: inverted(:)
 
       integer :: i, j, count
 
+      allocate(unicode(UTF8_CODE_MIN:UTF8_CODE_MAX))
+      allocate(inverted((UTF8_CODE_MIN-1):(UTF8_CODE_MAX+1)))
       unicode(:) = .false.
       inverted(:) = .false.
 

--- a/src/utf8_m.f90
+++ b/src/utf8_m.f90
@@ -33,7 +33,7 @@ contains
 
       do i = 0, 3
 
-         byte = ichar(str(curr+i:curr+i))
+         byte = int(ichar(str(curr+i:curr+i)), kind(byte))
 
          shift_3 = ishft(byte, -3)
          shift_4 = ishft(byte, -4)
@@ -95,16 +95,16 @@ contains
       bin = '0000000000000000000000000111111' ! lower 6-bit mask
       read(bin, '(b32.32)') mask
 
-      byte(1) = and(ishft(buf, -18), mask)
+      byte(1) = int(iand(ishft(buf, -18), mask),kind(byte))
       
       buf = code
-      byte(2) = and(ishft(buf, -12), mask)
+      byte(2) = int(iand(ishft(buf, -12), mask), kind(byte))
       
       buf = code
-      byte(3) = and(ishft(buf, -6), mask)
+      byte(3) = int(iand(ishft(buf, -6), mask), kind(byte))
       
       buf = code
-      byte(4) = and(buf, mask)
+      byte(4) = int(iand(buf, mask), kind(byte))
 
       if (code > 2**7-1) then
         
@@ -193,10 +193,10 @@ contains
          return
       end if
 
-      byte(1) = ichar(chara(1:1))
-      if (len(chara) >= 2) byte(2) = ichar(chara(2:2))
-      if (len(chara) >= 3) byte(3) = ichar(chara(3:3))
-      if (len(chara) >= 4) byte(4) = ichar(chara(4:4))
+      byte(1) = int(ichar(chara(1:1)),kind(byte))
+      if (len(chara) >= 2) byte(2) = int(ichar(chara(2:2)), kind(byte))
+      if (len(chara) >= 3) byte(3) = int(ichar(chara(3:3)), kind(byte))
+      if (len(chara) >= 4) byte(4) = int(ichar(chara(4:4)), kind(byte))
 
       shift_3 = ishft(byte(1), -3)
       shift_4 = ishft(byte(1), -4)
@@ -212,41 +212,41 @@ contains
       ! 4-byte character
       else if (shift_3 == 30) then
 
-         res = and(byte(1), mask_5_bit)
+         res = iand(byte(1), mask_5_bit)
 
          res = ishft(res, 6)
-         buf = and(byte(2), mask_2_bit)
-         res = or(res, buf)
+         buf = iand(byte(2), mask_2_bit)
+         res = ior(res, buf)
 
          res = ishft(res, 6)
-         buf = and(byte(3), mask_2_bit)
-         res = or(res, buf)
+         buf = iand(byte(3), mask_2_bit)
+         res = ior(res, buf)
 
          res = ishft(res, 6)
-         buf = and(byte(4), mask_2_bit)
-         res = or(res, buf)
+         buf = iand(byte(4), mask_2_bit)
+         res = ior(res, buf)
 
       ! 3-byte character
       else if (shift_4 == 14) then
          
-         res = and(byte(1), mask_4_bit)
+         res = iand(byte(1), mask_4_bit)
 
          res = ishft(res, 6)
-         buf = and(byte(2), mask_2_bit)
-         res = or(res, buf)
+         buf = iand(byte(2), mask_2_bit)
+         res = ior(res, buf)
 
          res = ishft(res, 6)
-         buf = and(byte(3), mask_2_bit)
-         res = or(res, buf)
+         buf = iand(byte(3), mask_2_bit)
+         res = ior(res, buf)
 
       ! 2-byte character
       else if (shift_5 == 6) then
 
-         res = and(byte(1), mask_3_bit)
+         res = iand(byte(1), mask_3_bit)
 
          res = ishft(res, 6)
-         buf = and(byte(2), mask_2_bit)
-         res = or(res, buf)
+         buf = iand(byte(2), mask_2_bit)
+         res = ior(res, buf)
 
       end if 
 
@@ -291,7 +291,7 @@ contains
       logical :: res
       integer(int8) :: byte, shift_6
 
-      byte = ichar(chara)
+      byte = int(ichar(chara), kind(byte))
 
       res = .true. 
 

--- a/test/test_case_001.f90
+++ b/test/test_case_001.f90
@@ -114,7 +114,6 @@ program test_001
    call runner_in("[^a-z]", "A", .true., res)
    call runner_match("[^a-z]", "B", .true., res)
 
-100 continue
 
    if (res) then
       print *, "=== TEST CASE 1 END ==="

--- a/test/test_case_002.f90
+++ b/test/test_case_002.f90
@@ -62,7 +62,6 @@ program test_002
    ! Zenkaku space
    call runner_match("\s", '　', .true., res)
    call runner_match('\s*', '　　', .true., res)
-100 continue
 
    if (res) then
       print *, "=== TEST CASE 2 END ===          "


### PR DESCRIPTION
addresses warnings and errors when compiling in gfortran with the following flags
`-g -Wall -Wextra -Werror -pedantic -std=f2018 -Wimplicit-interface -fcheck=all -fbacktrace -finit-real=snan -ffpe-trap=invalid,zero,overflow,underflow,denormall`