### PR TITLE
Invalid patterns#6

### DIFF
--- a/src/ast/syntax_tree_error_m.F90
+++ b/src/ast/syntax_tree_error_m.F90
@@ -19,6 +19,7 @@ module forgex_syntax_tree_error_m
       enumerator :: SYNTAX_ERR_CURLYBRACE_MISSING
       enumerator :: SYNTAX_ERR_CURLYBRACE_UNEXPECTED
       enumerator :: SYNTAX_ERR_INVALID_RANGE
+      enumerator :: SYNTAX_ERR_ESCAPED_SYMBOL_MISSING
    end enum
 
    character(*), parameter :: err_is_nothing    = "Given pattern is valid."
@@ -30,7 +31,7 @@ module forgex_syntax_tree_error_m
    character(*), parameter :: err_r_curlybrace_missing     = "ERROR: Closing right curlybrace is expected."
    character(*), parameter :: err_r_curlybrace_unexpected  = "ERROR: Unexpected closing right curlybrace error."
    character(*), parameter :: err_invalid_range            = "ERROR: Given range is invalid."
-
+   character(*), parameter :: err_escaped_symbol_missing   = "ERROR: Pattern cannot end with a trailing unescaped backslash."
 contains
 
    pure function get_error_message(code) result(msg)
@@ -43,21 +44,27 @@ contains
          msg = err_generic
       case (SYNTAX_ERR_PARENTHESIS_MISSING)
          msg = err_r_parenthesis_missing
+
       case (SYNTAX_ERR_PARENTHESIS_UNEXPECTED)
          msg = err_r_parenthesis_unexpected
 
       case (SYNTAX_ERR_BRACKET_MISSING)
          msg = err_r_bracket_missing
+
       case (SYNTAX_ERR_BRACKET_UNEXPECTED)
          msg = err_r_bracket_unexpected
 
       case (SYNTAX_ERR_CURLYBRACE_MISSING)
          msg = err_r_curlybrace_missing
+   
       case (SYNTAX_ERR_CURLYBRACE_UNEXPECTED)
          msg = err_r_curlybrace_unexpected
 
       case (SYNTAX_ERR_INVALID_RANGE)
          msg = err_invalid_range
+
+      case (SYNTAX_ERR_ESCAPED_SYMBOL_MISSING)
+         msg = err_escaped_symbol_missing
 
       case default
          msg = err_is_nothing

--- a/src/ast/syntax_tree_error_m.F90
+++ b/src/ast/syntax_tree_error_m.F90
@@ -20,6 +20,8 @@ module forgex_syntax_tree_error_m
       enumerator :: SYNTAX_ERR_CURLYBRACE_UNEXPECTED
       enumerator :: SYNTAX_ERR_INVALID_RANGE
       enumerator :: SYNTAX_ERR_ESCAPED_SYMBOL_MISSING
+      enumerator :: SYNTAX_ERR_ESCAPED_SYMBOL_INVALID
+      enumerator :: SYNTAX_ERR_EMPTY_CHARACTER_CLASS
    end enum
 
    character(*), parameter :: err_is_nothing    = "Given pattern is valid."
@@ -32,6 +34,9 @@ module forgex_syntax_tree_error_m
    character(*), parameter :: err_r_curlybrace_unexpected  = "ERROR: Unexpected closing right curlybrace error."
    character(*), parameter :: err_invalid_range            = "ERROR: Given range is invalid."
    character(*), parameter :: err_escaped_symbol_missing   = "ERROR: Pattern cannot end with a trailing unescaped backslash."
+   character(*), parameter :: err_escaped_symbol_invalid   = "ERROR: This token has no special meaning."
+   character(*), parameter :: err_empty_character_class    = "ERROR: Given class has no character."
+
 contains
 
    pure function get_error_message(code) result(msg)
@@ -65,6 +70,12 @@ contains
 
       case (SYNTAX_ERR_ESCAPED_SYMBOL_MISSING)
          msg = err_escaped_symbol_missing
+
+      case (SYNTAX_ERR_ESCAPED_SYMBOL_INVALID)
+         msg = err_escaped_symbol_invalid
+      
+      case (SYNTAX_ERR_EMPTY_CHARACTER_CLASS)
+         msg = err_empty_character_class
 
       case default
          msg = err_is_nothing

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -410,6 +410,8 @@ contains
       integer :: siz, ie, i, j, i_next, i_terminal
       logical :: is_inverted
 
+      siz = 0
+
       call self%tape%get_token(class_flag=.true.)
 
       buf = ''
@@ -429,8 +431,17 @@ contains
       end if
 
       siz = len_utf8(buf)
+    
+      ! Pattern '[-]' is valid.
 
+!-----この実装が悪い
       siz = siz - 2*count_token(buf(2:len_trim(buf)-1), SYMBOL_HYPN)
+
+      if (siz <= 0) then
+         self%is_valid_pattern = .false.
+         return
+      end if
+!-----ここまで
 
       if (buf(len_trim(buf):len_trim(buf)) == SYMBOL_HYPN) siz = siz -1
 
@@ -721,6 +732,30 @@ contains
    end subroutine tree_graph__range
 
 
+   pure function update_next_utf8_char_index(str, idx) result(res)
+      use :: forgex_utf8_m, only: idxutf8
+      use :: forgex_parameters_m, only: INVALID_CHAR_INDEX
+      implicit none
+      character(*), intent(in) :: str
+      integer, intent(in) :: idx
+      integer :: res
+
+      integer :: curr_end ! The index of the end of the multibyte character
+
+      curr_end = idxutf8(str, idx)
+
+      if (curr_end >= len(str)) then
+         res = INVALID_CHAR_INDEX
+
+      else if (curr_end == INVALID_CHAR_INDEX) then
+         res = INVALID_CHAR_INDEX
+      
+      else
+         ! curr_end is not invalid and is not the end of the string.
+         res = curr_end + 1
+      end if
+      
+   end function update_next_utf8_char_index
 
       
 !=====================================================================!

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -434,6 +434,10 @@ contains
 
       ! The variable siz stores the length of buf.
       siz = len_utf8(buf)
+      if (siz < 1) then
+         self%is_valid_pattern = .false.
+         return
+      end if
     
       ! Pattern '[-]' is valid.
 
@@ -759,7 +763,7 @@ contains
          res = INVALID_CHAR_INDEX
       
       else
-         ! curr_end is not invalid and is not the end of the string.
+         ! curr_end is valid and is not the end of the string.
          res = curr_end + 1
       end if
       
@@ -767,28 +771,50 @@ contains
 
 
    pure subroutine interpret_class_string(str, seglist, is_valid)
-      use :: forgex_utf8_m, only: idxutf8, next_idxutf8, len_utf8
-      use :: forgex_parameters_m, only: INVALID_CHAR_INDEX
+      use :: forgex_utf8_m, only: idxutf8, next_idxutf8, len_utf8, character_array_t, str2array => character_string_to_array
+      use :: forgex_parameters_m, only: INVALID_CHAR_INDEX, SYMBOL_BSLH
       implicit none
       character(*), intent(in) :: str
       type(segment_t), intent(inout), allocatable :: seglist(:)
       logical, intent(inout) :: is_valid
 
-      integer :: siz
-      integer :: i, ie ! current index
-      integer :: j, je ! next index
-      integer :: k, ke ! index of after the next
+      integer :: i, j, siz
+      type(character_array_t), allocatable :: ca(:) ! character array
 
-      
       is_valid = .true.
-      siz = len_utf8(str)
-      i  = 1
-      ie = idxutf8(str, i)
+      
+      call str2array(str, ca)
+      if (.not. allocated(ca)) then
+         is_valid = .false.
+         return
+      else if (siz < 1) then
+         is_valid = .false.
+         return
+      end if
 
-      j  = next_idxutf8(str, i)
-      je = idxutf8(str, j)
-      k  = next_idxutf8(str, j)
-      ke = idxutf8(str, k)
+      siz = size(ca, dim=1)
+
+      do i = 1, siz
+         if (ca(1)%c == SYMBOL_BSLH) then
+         else
+         end if
+      end do
+
+   contains
+
+      pure function extract(string, ibegin, iend) result(res)
+         implicit none
+         character(*), intent(in) :: string
+         integer, intent(in) :: ibegin, iend
+         character(:), allocatable :: res
+
+         res = ''
+         if (ibegin < 0 .or. iend < 0) return
+         if (ibegin > len(str) .or. iend > len(str)) return
+         if (ibegin > iend) return
+         
+         res = str(ibegin:iend)
+      end function extract
 
 
    end subroutine interpret_class_string

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -423,7 +423,7 @@ contains
       prev = ''
       curr = ''
       backslashed = .false.
-      do while (self%tape%current_token /= tk_rsbracket)
+      outer: do while (self%tape%current_token /= tk_rsbracket)
          prev = curr
          if (self%tape%current_token == tk_end) then
             return
@@ -433,13 +433,13 @@ contains
          curr = self%tape%token_char(1:ie)
          buf = buf//curr
 
-         call self%tape%get_token(class_flag=.true.)
-
-         if (curr == SYMBOL_BSLH .and. prev /= SYMBOL_BSLH) then
+         if (self%tape%current_token == tk_backslash .and. .not. backslashed) then
             backslashed = .true.
          else
             backslashed = .false.
          end if
+
+         call self%tape%get_token(class_flag=.true.)
          
          ! for an escaped right square bracket 
          if (self%tape%current_token == tk_rsbracket .and. backslashed) then
@@ -447,9 +447,10 @@ contains
             curr = self%tape%token_char(1:ie)
             buf = buf//curr
             call self%tape%get_token(class_flag=.true.)
+            backslashed = .false.
          end if
 
-      end do
+      end do outer
 
       ! If the character class pattern is empty, return false. 
       if (len(buf) == 0) then

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -461,7 +461,7 @@ contains
       is_inverted = .false.
       if (buf(1:1) == SYMBOL_CRET) then
          is_inverted = .true.
-         buf = buf(2:len(buf))
+         buf = buf(2:len(buf))  ! May this assignment be a problem?
       end if
 
       ! The variable siz stores the length of buf.

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -758,7 +758,6 @@ contains
       c = EMPTY_CHAR
       b = EMPTY_CHAR
       a = EMPTY_CHAR
-! write(0,*) "HOGE"
       call str2array(str, ca)
       if (.not. allocated(ca)) then
          is_valid = .false.
@@ -803,8 +802,7 @@ contains
                return
             end select
 
-            backslashed = .false.
-            cycle
+            backslashed = .false. 
          end if
 
          if (backslashed .and. hyphened) then

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -414,6 +414,7 @@ contains
 
       call self%tape%get_token(class_flag=.true.)
 
+      ! The variable buf stores the string representing the character class.
       buf = ''
       do while (self%tape%current_token /= tk_rsbracket)
          if (self%tape%current_token == tk_end) then
@@ -424,15 +425,22 @@ contains
          call self%tape%get_token(class_flag=.true.)
       end do
 
+      ! Handling a negative class case.
       is_inverted = .false.
       if (buf(1:1) == SYMBOL_CRET) then
          is_inverted = .true.
          buf = buf(2:len(buf))
       end if
 
+      ! The variable siz stores the length of buf.
       siz = len_utf8(buf)
     
       ! Pattern '[-]' is valid.
+
+      ! call interpret_class_string(buf, seglist, self%is_valid_pattern)
+      ! if (.not. self%is_valid_pattern) then
+      !    return
+      ! end if
 
 !-----この実装が悪い
       siz = siz - 2*count_token(buf(2:len_trim(buf)-1), SYMBOL_HYPN)
@@ -757,6 +765,33 @@ contains
       
    end function update_next_utf8_char_index
 
+
+   pure subroutine interpret_class_string(str, seglist, is_valid)
+      use :: forgex_utf8_m, only: idxutf8, next_idxutf8, len_utf8
+      use :: forgex_parameters_m, only: INVALID_CHAR_INDEX
+      implicit none
+      character(*), intent(in) :: str
+      type(segment_t), intent(inout), allocatable :: seglist(:)
+      logical, intent(inout) :: is_valid
+
+      integer :: siz
+      integer :: i, ie ! current index
+      integer :: j, je ! next index
+      integer :: k, ke ! index of after the next
+
+      
+      is_valid = .true.
+      siz = len_utf8(str)
+      i  = 1
+      ie = idxutf8(str, i)
+
+      j  = next_idxutf8(str, i)
+      je = idxutf8(str, j)
+      k  = next_idxutf8(str, j)
+      ke = idxutf8(str, k)
+
+
+   end subroutine interpret_class_string
       
 !=====================================================================!
   

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -432,6 +432,7 @@ contains
          ie = idxutf8(self%tape%token_char, 1)
          curr = self%tape%token_char(1:ie)
          buf = buf//curr
+
          call self%tape%get_token(class_flag=.true.)
 
          if (curr == SYMBOL_BSLH .and. prev /= SYMBOL_BSLH) then
@@ -449,6 +450,12 @@ contains
          end if
 
       end do
+
+      ! If the character class pattern is empty, return false. 
+      if (len(buf) == 0) then
+         self%is_valid_pattern = .false.
+         return
+      end if
 
       ! Handling a negative class case.
       is_inverted = .false.
@@ -751,7 +758,7 @@ contains
       c = EMPTY_CHAR
       b = EMPTY_CHAR
       a = EMPTY_CHAR
-
+! write(0,*) "HOGE"
       call str2array(str, ca)
       if (.not. allocated(ca)) then
          is_valid = .false.

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -615,7 +615,10 @@ contains
          seglist(5) = SEG_FF
          seglist(6) = SEG_ZENKAKU_SPACE
          call invert_segment_list(seglist)
-
+      case (EMPTY_CHAR)
+         self%code = SYNTAX_ERR_ESCAPED_SYMBOL_MISSING
+         self%is_valid_pattern = .false.
+         return
       case default
          chara = self%tape%token_char
          seg = segment_t(ichar_utf8(chara), ichar_utf8(chara))
@@ -879,7 +882,7 @@ contains
 
          if (c == SYMBOL_HYPN) then
             prev = b
-            if (a == SYMBOL_HYPN) then
+            if (a == SYMBOL_HYPN .or. b == SYMBOL_HYPN) then
                is_valid = .false.
                return
             else

--- a/src/ast/syntax_tree_node_m.F90
+++ b/src/ast/syntax_tree_node_m.F90
@@ -157,6 +157,9 @@ contains
                case (SYMBOL_HYPN)
                   self%current_token = tk_hyphen
                   self%token_char = c
+               case (SYMBOL_BSLH)
+                  self%current_token = tk_backslash
+                  self%token_char = c
                case default
                   self%current_token = tk_char
                   self%token_char = c

--- a/src/ast/syntax_tree_node_m.F90
+++ b/src/ast/syntax_tree_node_m.F90
@@ -153,6 +153,7 @@ contains
                select case (trim(c))
                case (SYMBOL_RSBK)
                   self%current_token = tk_rsbracket
+                  self%token_char = c
                case (SYMBOL_HYPN)
                   self%current_token = tk_hyphen
                   self%token_char = c

--- a/src/ast/syntax_tree_node_m.F90
+++ b/src/ast/syntax_tree_node_m.F90
@@ -130,7 +130,7 @@ contains
    !  `current_token` component.
    !  This is a type-bound procedure of `tape_t`.
    pure subroutine get_token(self, class_flag)
-      use :: forgex_utf8_m, only: idxutf8
+      use :: forgex_utf8_m, only: idxutf8, next_idxutf8
       implicit none
       class(tape_t),     intent(inout) :: self
       logical, optional, intent(in)    :: class_flag
@@ -139,7 +139,7 @@ contains
       integer(int32)            :: ib, ie
 
       ib = self%idx
-      if (ib > len(self%str)) then
+      if (ib == INVALID_CHAR_INDEX .or. ib > len(self%str)) then
          self%current_token = tk_end
          self%token_char = ''
       else
@@ -177,11 +177,10 @@ contains
                self%current_token = tk_question
             case (SYMBOL_BSLH)
                self%current_token = tk_backslash
-
-               ib = ie +1
+               ib = next_idxutf8(self%str, ie)
                ie = idxutf8(self%str, ib)
-
                self%token_char = self%str(ib:ie)
+
             case (SYMBOL_LSBK)
                self%current_token = tk_lsbracket
             case (SYMBOL_RSBK)
@@ -202,7 +201,7 @@ contains
             end select
          end if
 
-         self%idx = ie + 1
+         self%idx = next_idxutf8(self%str, ib)
 
       end if
    end subroutine get_token

--- a/src/essential/parameters_m.f90
+++ b/src/essential/parameters_m.f90
@@ -27,7 +27,7 @@ module forgex_parameters_m
 
    integer(int32), parameter :: INVALID_REPEAT_VAL = -1
    integer(int32), parameter :: INFINITE = -2
-   integer, parameter, public :: INVALID_CHAR_INDEX = -1
+   integer, parameter, public :: INVALID_CHAR_INDEX = -9999
 
    ! For handling UTF-8
    integer(int32), parameter, public :: UTF8_CODE_MAX     = 2**21-1 !
@@ -66,7 +66,7 @@ module forgex_parameters_m
 
    !> This constant is used to indicate that the left and right destination
    !> have not yet been registered.
-   integer(int32), parameter, public :: INVALID_INDEX  = -1
+   integer(int32), parameter, public :: INVALID_INDEX  = -9999
 
    !> This constant is used to represent a terminal node in a syntax tree that
    !> has no destination nodes to the left or right.

--- a/src/essential/parameters_m.f90
+++ b/src/essential/parameters_m.f90
@@ -38,6 +38,7 @@ module forgex_parameters_m
 
    ! These character constants represent characters that have special
    ! meaning in regular expression parsing.
+   character(0), parameter, public :: EMPTY_CHAR  = ''
    character(1), parameter, public :: SYMBOL_VBAR = '|'  ! vartical bar
    character(1), parameter, public :: SYMBOL_LPAR = '('  ! left parentheses
    character(1), parameter, public :: SYMBOL_RPAR = ')'  ! right parentheses

--- a/src/essential/parameters_m.f90
+++ b/src/essential/parameters_m.f90
@@ -29,6 +29,9 @@ module forgex_parameters_m
    integer(int32), parameter :: INFINITE = -2
    integer, parameter, public :: INVALID_CHAR_INDEX = -9999
 
+   integer(int32), parameter :: SEGMENT_REGISTERED = 0
+   integer(int32), parameter :: SEGMENT_REJECTED = 1
+
    ! For handling UTF-8
    integer(int32), parameter, public :: UTF8_CODE_MAX     = 2**21-1 !
    integer(int32), parameter, public :: UTF8_CODE_MIN     = 32 ! = 0x20: white space

--- a/src/essential/segment_m.F90
+++ b/src/essential/segment_m.F90
@@ -23,6 +23,8 @@ module forgex_segment_m
 
    public :: sort_segment_by_min
    public :: merge_segments
+   public :: segment_is_valid
+   public :: register_segment_to_list
 
    !> This derived-type represents a contiguous range of the Unicode character set
    !> as a `min` and `max` value, providing an effective way to represent ranges of characters
@@ -176,8 +178,10 @@ contains
       implicit none
       class(segment_t), intent(in) :: self
       logical :: res
+      type(segment_t) :: init
 
-      res = self%min <= self%max
+      res = self%min /= init%min .and. self%max /= init%max &
+      .and. self%min <= self%max
    end function segment_is_valid
 
 
@@ -308,6 +312,18 @@ contains
       ! Create a segment corresponding to the code, and return it.
       res = segment_t(code, code)
    end function symbol_to_segment
+
+
+   pure subroutine register_segment_to_list(segment_list, segment, k)
+      implicit none
+      type(segment_t), intent(inout) :: segment_list(:)
+      type(segment_t), intent(inout) :: segment
+      integer, intent(inout) :: k
+      k = k + 1
+      segment_list(k) = segment
+      segment = segment_t()
+   end subroutine register_segment_to_list
+
 
 !====================================================================-!
 !  Helper procedures

--- a/src/essential/segment_m.F90
+++ b/src/essential/segment_m.F90
@@ -314,6 +314,8 @@ contains
    end function symbol_to_segment
 
 
+   !> This procedure registers given segment_t value to segment_t type array,
+   !> increments counter of the actual size of the array, and initializes temporary variable.
    pure subroutine register_segment_to_list(segment_list, segment, k, ierr)
       use :: forgex_parameters_m, only: SEGMENT_REGISTERED, SEGMENT_REJECTED
       implicit none
@@ -321,10 +323,14 @@ contains
       type(segment_t), intent(inout) :: segment
       integer, intent(inout) :: k
       integer, intent(inout) :: ierr
+
       if (segment%validate()) then
          k = k + 1
-         segment_list(k) = segment
-         segment = segment_t()
+
+         segment_list(k) = segment ! register
+         
+         segment = segment_t() ! initialze
+
          ierr = SEGMENT_REGISTERED
       else
          ierr = SEGMENT_REJECTED

--- a/src/essential/segment_m.F90
+++ b/src/essential/segment_m.F90
@@ -314,14 +314,21 @@ contains
    end function symbol_to_segment
 
 
-   pure subroutine register_segment_to_list(segment_list, segment, k)
+   pure subroutine register_segment_to_list(segment_list, segment, k, ierr)
+      use :: forgex_parameters_m, only: SEGMENT_REGISTERED, SEGMENT_REJECTED
       implicit none
       type(segment_t), intent(inout) :: segment_list(:)
       type(segment_t), intent(inout) :: segment
       integer, intent(inout) :: k
-      k = k + 1
-      segment_list(k) = segment
-      segment = segment_t()
+      integer, intent(inout) :: ierr
+      if (segment%validate()) then
+         k = k + 1
+         segment_list(k) = segment
+         segment = segment_t()
+         ierr = SEGMENT_REGISTERED
+      else
+         ierr = SEGMENT_REJECTED
+      end if
    end subroutine register_segment_to_list
 
 

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -526,7 +526,7 @@ contains
 
    !> This subroutine parses a pattern string for character class,
    !> and outputs `character_array_t` type array.
-   ! 
+   !> When it encounters invalid value along the way, it returns.
    pure subroutine character_string_to_array(str, array)
       use :: forgex_parameters_m, only: INVALID_CHAR_INDEX
       implicit none

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -41,6 +41,12 @@ contains
          ! Shifted byte values.
 
 
+      ! If the index exceeds the length of str, return the invalid value.
+      if (curr > len(str)) then
+         tail = INVALID_CHAR_INDEX
+         return
+      end if
+
       tail = curr    ! Initialize tail to the current index.
 
       do i = 0, 3    ! Loop over the next four bytes to determine the byte-length of the character.

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -16,6 +16,7 @@ module forgex_utf8_m
    type :: character_array_t
       character(:), allocatable :: c
       logical :: is_escaped = .false.
+      logical :: is_hyphened = .false.
    end type
 
    public :: character_array_t
@@ -30,7 +31,7 @@ module forgex_utf8_m
    public :: adjustl_multi_byte
    public :: trim_invalid_utf8_byte
    public :: character_string_to_array
-   public :: parse_backslash_in_char_array
+   public :: parse_backslash_and_hyphen_in_char_array
 
 contains
 
@@ -545,7 +546,7 @@ contains
    end subroutine character_string_to_array
       
    
-   pure subroutine parse_backslash_in_char_array(array)
+   pure subroutine parse_backslash_and_hyphen_in_char_array(array)
       use :: forgex_parameters_m
       implicit none
       type(character_array_t), intent(inout), allocatable :: array(:)
@@ -561,6 +562,8 @@ contains
       do i = 1, size(array, dim=1)
          if (array(i)%c == SYMBOL_BSLH .and. .not. temp(k)%is_escaped) then
             temp(k)%is_escaped = .true.
+         else if (array(i)%c == SYMBOL_HYPN .and. .not. i == 1) then
+            temp(k-1)%is_hyphened = .true.
          else
             temp(k)%c = array(i)%c
             k = k + 1
@@ -573,7 +576,7 @@ contains
 
       array(:) = temp(1:siz)
       
-   end subroutine parse_backslash_in_char_array
+   end subroutine parse_backslash_and_hyphen_in_char_array
 
 
 end module forgex_utf8_m

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -13,6 +13,11 @@ module forgex_utf8_m
    implicit none
    private
 
+   type :: character_array_t
+      character(:), allocatable :: c
+   end type
+
+   public :: character_array_t
    public :: idxutf8
    public :: next_idxutf8
    public :: char_utf8, ichar_utf8
@@ -23,6 +28,7 @@ module forgex_utf8_m
    public :: is_valid_multiple_byte_character
    public :: adjustl_multi_byte
    public :: trim_invalid_utf8_byte
+   public :: character_string_to_array
 
 contains
 
@@ -510,5 +516,31 @@ contains
       end if
    
    end function trim_invalid_utf8_byte
+
+   pure subroutine character_string_to_array(str, array)
+      use :: forgex_parameters_m, only: INVALID_CHAR_INDEX
+      implicit none
+      character(*), intent(in) :: str
+      type(character_array_t), intent(inout), allocatable :: array(:)
+
+      integer :: siz, ib, ie, j
+
+      siz = len_utf8(str)
+      if (siz < 1) return
+
+      if (allocated(array)) deallocate(array)
+      allocate(array(siz))
+
+      ib = 0
+      ie = 0
+      do j = 1, siz
+         ib = ie + 1
+         ie = idxutf8(str, ib)
+         if (ib == INVALID_CHAR_INDEX .or. ie == INVALID_CHAR_INDEX) return
+         array(j)%c = str(ib:ie)
+      end do
+
+   end subroutine character_string_to_array
+      
 
 end module forgex_utf8_m

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -15,6 +15,7 @@ module forgex_utf8_m
 
    type :: character_array_t
       character(:), allocatable :: c
+      logical :: is_escaped = .false.
    end type
 
    public :: character_array_t
@@ -29,6 +30,7 @@ module forgex_utf8_m
    public :: adjustl_multi_byte
    public :: trim_invalid_utf8_byte
    public :: character_string_to_array
+   public :: parse_backslash_in_char_array
 
 contains
 
@@ -542,5 +544,36 @@ contains
 
    end subroutine character_string_to_array
       
+   
+   pure subroutine parse_backslash_in_char_array(array)
+      use :: forgex_parameters_m
+      implicit none
+      type(character_array_t), intent(inout), allocatable :: array(:)
+      type(character_array_t), allocatable :: temp(:)
+      integer :: i, k, siz
+
+      if (.not. allocated(array)) return
+      if (size(array, dim=1) < 1) return 
+
+      allocate(temp(size(array, dim=1)))
+
+      k = 1
+      do i = 1, size(array, dim=1)
+         if (array(i)%c == SYMBOL_BSLH .and. .not. temp(k)%is_escaped) then
+            temp(k)%is_escaped = .true.
+         else
+            temp(k)%c = array(i)%c
+            k = k + 1
+         end if
+      end do
+
+      siz = k - 1
+      if (allocated(array)) deallocate(array)
+      allocate(array(siz))
+
+      array(:) = temp(1:siz)
+      
+   end subroutine parse_backslash_in_char_array
+
 
 end module forgex_utf8_m

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -14,6 +14,7 @@ module forgex_utf8_m
    private
 
    public :: idxutf8
+   public :: next_idxutf8
    public :: char_utf8, ichar_utf8
    public :: count_token
    public :: is_first_byte_of_character
@@ -95,6 +96,29 @@ contains
       end do
 
    end function idxutf8
+
+
+   !> This function returns the index of the next character,
+   !> given the string str and the current index curr.
+   !> If the current index is for the last character, it returns the invalid value.
+   pure function next_idxutf8(str, curr) result(res)
+      use :: forgex_parameters_m
+      implicit none
+      character(*), intent(in) :: str
+      integer, intent(in) :: curr
+      
+      integer :: res
+      integer :: curr_end
+
+      curr_end = idxutf8(str, curr)
+
+      if (curr_end /= INVALID_CHAR_INDEX) then
+         res = curr_end + 1
+      else
+         res = INVALID_CHAR_INDEX
+      end if
+      
+   end function next_idxutf8
 
 
    pure function is_valid_multiple_byte_character(chara) result(res)

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -553,7 +553,8 @@ contains
    end subroutine character_string_to_array
       
    !> This subroutine processes a character array, and outputs the corresponding
-   !> flagged array. It removes backslash and hyphen characters, 
+   !> flagged array. It removes backslash and hyphen characters, and then flags 
+   !> the current element in `character_array_t` type array.
    pure subroutine parse_backslash_and_hyphen_in_char_array(array)
       use :: forgex_parameters_m
       implicit none

--- a/test/test_api/test_case_008.f90
+++ b/test/test_api/test_case_008.f90
@@ -1,0 +1,45 @@
+program test_case_008
+   use ::forgex_test_m
+   implicit none
+
+   logical :: res = .true.
+
+   ! Corner cases
+   print *, "=== TEST CASE 7 BEGIN ==="
+
+   call runner_match("[]", "", .false., res)
+   call runner_match("[-]", "-", .true., res)
+   call runner_match("[+]", "+", .true., res)
+
+   call runner_match("[\{]", "{", .true. , res)
+   call runner_match("[\{]+", "{{", .true. , res)
+
+   call runner_match("[\[]", "[", .true. , res)
+   call runner_match("[\[]+", "[[", .true. , res)
+   call runner_match("[\[-\]]", "[", .true. , res)
+   call runner_match("[\[-\]]", "\", .true. , res)
+   call runner_match("[\]]", "]", .true. , res)
+
+   call runner_match("[\{-\}]", "{", .true. , res)
+   call runner_match("[\{-\}]", "|", .true. , res)
+   call runner_match("[-\{-\}]*", "{|}", .true. , res)
+   call runner_match("[\}]", "}", .true. , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+   ! call runner_match("", "", , res)
+
+
+   if (res) then
+      print *, "=== TEST CASE 7 END ==="
+      stop
+   else
+      error stop "There are cases where the match fails."
+   end if
+end program test_case_008

--- a/test/test_api/test_case_008.f90
+++ b/test/test_api/test_case_008.f90
@@ -27,8 +27,16 @@ program test_case_008
    call runner_match("[\{-\}]", "|", .true. , res)
    call runner_match("[-\{-\}]*", "{|}", .true. , res)
    call runner_match("[\}]", "}", .true. , res)
-   ! call runner_match("", "", , res)
-   ! call runner_match("", "", , res)
+
+   call runner_match("(a*)*", "aaa", .true., res)
+   call runner_match("(.+)*", "xyz", .true., res)
+   call runner_match("(\d+)?", "", .true., res)
+   call runner_match("(\d{2,4}-\d{2,4}-\d{2,4})", "1234-567-890", .true., res)
+   call runner_match("(\d{2,4}-\d{2,4}-\d{2,4})", "1234--567", .false., res)
+   call runner_match("(\w+\s*)+", "Hi Alice", .true., res)
+   call runner_match("(\w+\s*)+", "123456", .true., res)
+   call runner_match("(\w+\s*)+", "123456 foo", .true., res)
+
    ! call runner_match("", "", , res)
    ! call runner_match("", "", , res)
    ! call runner_match("", "", , res)

--- a/test/test_api/test_case_008.f90
+++ b/test/test_api/test_case_008.f90
@@ -16,6 +16,9 @@ program test_case_008
 
    call runner_match("[\[]", "[", .true. , res)
    call runner_match("[\[]+", "[[", .true. , res)
+   call runner_match("[\\]", "\", .true., res)
+   call runner_match("[\\\]]", "]", .true., res)
+   call runner_match("[\\\]]", "\", .true., res)
    call runner_match("[\[-\]]", "[", .true. , res)
    call runner_match("[\[-\]]", "\", .true. , res)
    call runner_match("[\]]", "]", .true. , res)

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -60,6 +60,10 @@ program main
    call runner_validate("[^]", .false., res)
    call runner_validate("[\{]", .true., res)
 
+   call runner_validate("[\\]", .true., res)
+   call runner_validate("[\\\]]", .true., res)
+   call runner_validate("[\\\]]", .true., res)
+
 
 !=====================================================================!
    if (res) then

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -64,6 +64,10 @@ program main
    call runner_validate("[\\\]]", .true., res)
    call runner_validate("[\\\]]", .true., res)
 
+   call runner_validate("[a-z]", .true., res)
+   call runner_validate("[\a]", .false., res)
+   call runner_validate("[z-a]", .false., res)
+
 
 !=====================================================================!
    if (res) then

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -49,6 +49,9 @@ program main
 
    call runner_validate("[]", .false., res)
    call runner_validate("[-]", .true., res)
+   call runner_validate("[--]", .false., res)
+   call runner_validate("[---]", .false., res)
+
    call runner_validate("[+]", .true., res)
    call runner_validate("[\[-\]]", .true., res)
    call runner_validate("[\[-\\]", .true., res)
@@ -67,7 +70,12 @@ program main
    call runner_validate("[a-z]", .true., res)
    call runner_validate("[\a]", .false., res)
    call runner_validate("[z-a]", .false., res)
+   call runner_validate("[a-]", .false., res)
+   call runner_validate("[\{-]", .false., res)
+   
+   call runner_validate("(a*)*", .true., res)
 
+   call runner_validate("(\w+\s*)+", .true., res)
 
 !=====================================================================!
    if (res) then

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -54,6 +54,11 @@ program main
    call runner_validate("[\[-\\]", .true., res)
    call runner_validate("[a]{3,4}", .true., res)
    call runner_validate("[--]", .false., res)
+   call runner_validate("\\\", .false., res)
+   call runner_validate("\\", .true., res)
+   call runner_validate("\", .false., res)
+
+
 
 !=====================================================================!
    if (res) then

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -58,7 +58,7 @@ program main
    call runner_validate("\\", .true., res)
    call runner_validate("\", .false., res)
    call runner_validate("[^]", .false., res)
-
+   call runner_validate("[\{]", .true., res)
 
 
 !=====================================================================!

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -49,7 +49,11 @@ program main
 
    call runner_validate("[]", .false., res)
    call runner_validate("[-]", .true., res)
-
+   call runner_validate("[+]", .true., res)
+   call runner_validate("[\[-\]]", .true., res)
+   call runner_validate("[\[-\\]", .true., res)
+   call runner_validate("[a]{3,4}", .true., res)
+   call runner_validate("[--]", .false., res)
 
 !=====================================================================!
    if (res) then

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -47,6 +47,9 @@ program main
    call runner_validate("a{1,b}", .false., res)
    call runner_validate("a{2,1}", .false., res)
 
+   call runner_validate("[]", .false., res)
+   call runner_validate("[-]", .true., res)
+
 
 !=====================================================================!
    if (res) then

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -57,6 +57,7 @@ program main
    call runner_validate("\\\", .false., res)
    call runner_validate("\\", .true., res)
    call runner_validate("\", .false., res)
+   call runner_validate("[^]", .false., res)
 
 
 

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -52,6 +52,9 @@ program main
    call runner_validate("[--]", .false., res)
    call runner_validate("[---]", .false., res)
 
+   call runner_validate("[{]", .true., res)
+   call runner_validate("[}]", .true., res)
+
    call runner_validate("[+]", .true., res)
    call runner_validate("[\[-\]]", .true., res)
    call runner_validate("[\[-\\]", .true., res)
@@ -76,7 +79,7 @@ program main
    call runner_validate("(a*)*", .true., res)
 
    call runner_validate("(\w+\s*)+", .true., res)
-
+   
 !=====================================================================!
    if (res) then
       print *, "=== PATTRERN VALIDATE CASE 2 END ==="


### PR DESCRIPTION
This PR contains following updates and fixes:
- fundamental implementation changes to character class handling,
- fixes to properly handle cases pointed out in the issue #6, such as `[]`, `[-]`, `\\\`, etc.

This PR does NOT contain following update:
- handling non-Unicode string input,
- any solution for unescaped curly braces discussed on #7.