### PR TITLE
Non-UTF-8 String input#9

### DIFF
--- a/src/api_internal_m.F90
+++ b/src/api_internal_m.F90
@@ -227,7 +227,6 @@ contains
       ! True if the prefix is empty or matches, and the suffix is empty or matches.
       runs_engine = (empty_pre .or. matches_pre) .and. (empty_post .or. matches_post)
 
-
       if (.not. runs_engine) then
          res = .false.
          return
@@ -264,19 +263,18 @@ contains
          end if
 
          if (ci > len(str)) exit
-
          ! Get the index of the next character and assign it to `next_ci`.
          ! next_ci = next_idxutf8(str, ci)
          call next_idxutf8_strict(str, ci, next_ci, is_valid_utf8_char)
+
+         ! Lazy evaluation is performed by calling this procedure here.
+         ! The index of destination DFA node is stored in the `dst_i` variable.
          if (is_valid_utf8_char) then
             call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
          else
             call automaton%construct(cur_i, dst_i, make_replacement_char())
          end if
 
-         ! Lazy evaluation is performed by calling this procedure here.
-         ! The index of destination DFA node is stored in the `dst_i` variable.
-         call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
 
          ! If there is mismatch in the first byte of the NULL character, try again with the second byte.
          if (dst_i == DFA_INVALID_INDEX .and. ci == 1) then

--- a/src/api_internal_m.F90
+++ b/src/api_internal_m.F90
@@ -17,7 +17,7 @@ module forgex_api_internal_m
    use, intrinsic :: iso_fortran_env, only: stderr => error_unit
    use :: forgex_parameters_m, only: DFA_NOT_INIT, DFA_INVALID_INDEX
    use :: forgex_automaton_m, only: automaton_t
-   use :: forgex_utf8_m, only: idxutf8
+   use :: forgex_utf8_m, only: next_idxutf8
    implicit none
    private
 
@@ -124,7 +124,7 @@ contains
 
             if (ci > len(str)) exit
 
-            next_ci = idxutf8(str, ci) + 1
+            next_ci = next_idxutf8(str, ci)
 
             call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
 
@@ -145,7 +145,7 @@ contains
          end if
 
          if (do_brute_force) then
-            start = idxutf8(str, start) + 1 ! Bruteforce searching
+            start = next_idxutf8(str, start) ! Bruteforce searching
             cycle
          endif
 
@@ -260,7 +260,7 @@ contains
          if (ci > len(str)) exit
 
          ! Get the index of the next character and assign it to `next_ci`.
-         next_ci = idxutf8(str, ci) + 1
+         next_ci = next_idxutf8(str, ci)
 
          ! Lazy evaluation is performed by calling this procedure here.
          ! The index of destination DFA node is stored in the `dst_i` variable.
@@ -269,7 +269,7 @@ contains
          ! If there is mismatch in the first byte of the NULL character, try again with the second byte.
          if (dst_i == DFA_INVALID_INDEX .and. ci == 1) then
             ci = 2
-            next_ci = idxutf8(str, ci) + 1
+            next_ci = next_idxutf8(str, ci)
             call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
          end if
 

--- a/src/api_internal_m.F90
+++ b/src/api_internal_m.F90
@@ -17,7 +17,7 @@ module forgex_api_internal_m
    use, intrinsic :: iso_fortran_env, only: stderr => error_unit
    use :: forgex_parameters_m, only: DFA_NOT_INIT, DFA_INVALID_INDEX
    use :: forgex_automaton_m, only: automaton_t
-   use :: forgex_utf8_m, only: next_idxutf8
+   use :: forgex_utf8_m, only: next_idxutf8_strict, make_replacement_char
    implicit none
    private
 
@@ -47,7 +47,7 @@ contains
       integer :: suf_idx      ! right-most suffix index
       character(:), allocatable :: str
       integer, allocatable :: index_list(:)
-      logical :: do_brute_force
+      logical :: do_brute_force, is_valid_utf8_char
 
       do_brute_force = .false.
       runs_engine = .false.
@@ -124,10 +124,14 @@ contains
 
             if (ci > len(str)) exit
 
-            next_ci = next_idxutf8(str, ci)
+            call next_idxutf8_strict(str, ci, next_ci, is_valid_utf8_char)
 
-            call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
-
+            if (is_valid_utf8_char) then
+               call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
+            else
+               call automaton%construct(cur_i, dst_i, make_replacement_char())
+            end if
+            
             cur_i = dst_i
             ci = next_ci
          end do
@@ -145,7 +149,8 @@ contains
          end if
 
          if (do_brute_force) then
-            start = next_idxutf8(str, start) ! Bruteforce searching
+            call next_idxutf8_strict(str, start, start, is_valid_utf8_char)
+            ! start = next_idxutf8(str, start) ! Bruteforce searching
             cycle
          endif
 
@@ -181,6 +186,7 @@ contains
 
       integer :: len_pre, len_suf, n
       logical :: empty_pre, empty_post, matches_pre, matches_post
+      logical :: is_valid_utf8_char
 
       runs_engine = .false.
 
@@ -260,7 +266,13 @@ contains
          if (ci > len(str)) exit
 
          ! Get the index of the next character and assign it to `next_ci`.
-         next_ci = next_idxutf8(str, ci)
+         ! next_ci = next_idxutf8(str, ci)
+         call next_idxutf8_strict(str, ci, next_ci, is_valid_utf8_char)
+         if (is_valid_utf8_char) then
+            call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
+         else
+            call automaton%construct(cur_i, dst_i, make_replacement_char())
+         end if
 
          ! Lazy evaluation is performed by calling this procedure here.
          ! The index of destination DFA node is stored in the `dst_i` variable.
@@ -269,8 +281,13 @@ contains
          ! If there is mismatch in the first byte of the NULL character, try again with the second byte.
          if (dst_i == DFA_INVALID_INDEX .and. ci == 1) then
             ci = 2
-            next_ci = next_idxutf8(str, ci)
-            call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
+            ! next_ci = next_idxutf8(str, ci)
+            call next_idxutf8_strict(str, ci, next_ci, is_valid_utf8_char)
+            if (is_valid_utf8_char) then
+               call automaton%construct(cur_i, dst_i, str(ci:next_ci-1))
+            else
+               call automaton%construct(cur_i, dst_i, make_replacement_char())
+            end if
          end if
 
          ! update counters

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -3,7 +3,6 @@ add_library(ast STATIC
    syntax_tree_node_m.F90
    syntax_tree_graph_m.F90
    syntax_tree_optimize_m.F90
-   syntax_tree_error_m.F90
 )
 
 set_target_properties(ast PROPERTIES

--- a/src/ast/character_array_m.F90
+++ b/src/ast/character_array_m.F90
@@ -72,7 +72,7 @@ contains
    !> the current element in `character_array_t` type array.
    pure subroutine parse_backslash_and_hyphen_in_char_array(array, ierr)
       use :: forgex_parameters_m
-      use :: forgex_syntax_tree_error_m
+      use :: forgex_error_m
       implicit none
       type(character_array_t), intent(inout), allocatable :: array(:)
       type(character_array_t), allocatable :: temp(:)

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -15,7 +15,7 @@ module forgex_syntax_tree_graph_m
    use :: forgex_segment_m
    use :: forgex_syntax_tree_node_m, &
       only: tree_node_t, tape_t, terminal, make_atom, make_tree_node, make_repeat_node
-   use :: forgex_syntax_tree_error_m
+   use :: forgex_error_m
    implicit none
    private
 

--- a/src/dense_dfa/dense_dfa_m.f90
+++ b/src/dense_dfa/dense_dfa_m.f90
@@ -198,7 +198,7 @@ contains
    !> This procedure reads a text, performs regular expression matching using compiled DFA,
    !> and returns `.true.` if it matches exactly.
    pure function match_dense_dfa_exactly(automaton, string) result(res)
-      use :: forgex_utf8_m, only: idxutf8
+      use :: forgex_utf8_m, only: next_idxutf8
       implicit none
       type(automaton_t), intent(in) :: automaton
       character(*), intent(in) :: string
@@ -229,7 +229,7 @@ contains
 
          if (ci > len(string)) exit
 
-         next_ci = idxutf8(string, ci) + 1
+         next_ci = next_idxutf8(string, ci)
 
          dst_i = next_state_dense_dfa(automaton, cur_i, string(ci:next_ci-1))
 
@@ -247,7 +247,7 @@ contains
    !> This procedure reads a text, performs regular expression matching using an automaton,
    !> and stores the string index in the argument if it contains a match.
    subroutine match_dense_dfa_including(automaton, string, from, to)
-      use :: forgex_utf8_m, only: idxutf8
+      use :: forgex_utf8_m, only: next_idxutf8
       implicit none
       type(automaton_t), intent(in) :: automaton
       character(*), intent(in) :: string
@@ -289,7 +289,7 @@ contains
 
             if (ci > len(string)) exit
 
-            next_ci = idxutf8(string, ci) + 1
+            next_ci = next_idxutf8(string, ci)
 
             dst_i = next_state_dense_dfa(automaton, cur_i, string(ci:next_ci-1))
             cur_i = dst_i
@@ -303,7 +303,7 @@ contains
             return
          end if
 
-         start = idxutf8(string, start) +1
+         start = next_idxutf8(string, start)
       end do
    end subroutine match_dense_dfa_including
 

--- a/src/essential/CMakeLists.txt
+++ b/src/essential/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(essential STATIC
    enums_m.f90
+   error_m.f90
    parameters_m.f90
    priority_queue_m.f90
    segment_m.F90

--- a/src/essential/error_m.F90
+++ b/src/essential/error_m.F90
@@ -4,9 +4,9 @@
 !
 ! (C) Amasaki Shinobu, 2023-2025
 !     A regular expression engine for Fortran.
-!     forgex_syntax_tree_error_m module is a part of Forgex.
+!     forgex_error_m module is a part of Forgex.
 !
-module forgex_syntax_tree_error_m
+module forgex_error_m
    implicit none
    
    enum, bind(c)
@@ -127,4 +127,4 @@ contains
    end function get_error_message
 
 
-end module forgex_syntax_tree_error_m
+end module forgex_error_m

--- a/src/essential/utf8_m.f90
+++ b/src/essential/utf8_m.f90
@@ -142,12 +142,12 @@ contains
    end function next_idxutf8
 
 
-   pure subroutine next_idxutf8_strict(str, curr, tail, is_valid)
+   pure subroutine next_idxutf8_strict(str, curr, next, is_valid)
       use :: forgex_parameters_m
       implicit none
       character(*), intent(in)    :: str
       integer,      intent(in)    :: curr
-      integer,      intent(inout) :: tail
+      integer,      intent(inout) :: next
       logical,      intent(inout) :: is_valid
 
       integer :: ib, ie
@@ -159,9 +159,9 @@ contains
 
       if (ie /= INVALID_CHAR_INDEX) then
          is_valid = is_valid_multiple_byte_character(str(ib:ie))
-         tail = ie + 1
+         next = ie + 1
       else
-         tail = curr
+         next = curr+1
          is_valid = .false.
       end if
 
@@ -190,7 +190,10 @@ contains
       shift_7 = ishft(byte, -7)  ! Right shift the byte by 7 bits
 
       ! 1st byte
-      if (shift_3 == 30) then
+      if (shift_3 == 31) then  ! 5-byte character (invalid)
+         res = .false.
+         return
+      else if (shift_3 == 30) then
          expected_siz = 4
       else if (shift_4 == 14)then
          expected_siz = 3 

--- a/src/forgex.F90
+++ b/src/forgex.F90
@@ -231,7 +231,7 @@ contains
    !> The function implemented for the `regex` subroutine.
    pure subroutine subroutine__regex(pattern, text, res, length, from, to, status, err_msg)
       use :: forgex_parameters_m, only: ACCEPTED_EMPTY, INVALID_CHAR_INDEX
-      use :: forgex_error_m, only: get_error_message
+      use :: forgex_error_m, only: get_error_message, SYNTAX_VALID
       implicit none
       character(*),              intent(in)    :: pattern, text
       character(:), allocatable, intent(inout) :: res

--- a/src/forgex.F90
+++ b/src/forgex.F90
@@ -231,7 +231,7 @@ contains
    !> The function implemented for the `regex` subroutine.
    pure subroutine subroutine__regex(pattern, text, res, length, from, to, status, err_msg)
       use :: forgex_parameters_m, only: ACCEPTED_EMPTY, INVALID_CHAR_INDEX
-      use :: forgex_syntax_tree_error_m, only: get_error_message
+      use :: forgex_error_m, only: get_error_message
       implicit none
       character(*),              intent(in)    :: pattern, text
       character(:), allocatable, intent(inout) :: res

--- a/src/test_m.f90
+++ b/src/test_m.f90
@@ -165,7 +165,7 @@ contains
 
    !> This function checks whether it returns the correct error for a given pattern and text.
    function is_valid__error (pattern, text, expected_err_code, return_code) result(res)
-      use :: forgex_syntax_tree_error_m
+      use :: forgex_error_m
       implicit none
       character(*), intent(in) :: pattern
       character(*), intent(in) :: text
@@ -335,7 +335,7 @@ contains
 
    !> This subroutine runs `is_valid_error` function and prints its result.
    subroutine runner_error(pattern, text, code, result)
-      use :: forgex_syntax_tree_error_m
+      use :: forgex_error_m
       implicit none
       character(*), intent(in) :: pattern, text
       integer, intent(in) :: code

--- a/test/test_error/error_case_001.f90
+++ b/test/test_error/error_case_001.f90
@@ -1,6 +1,6 @@
 program error_case_001
    use :: forgex_test_m
-   use :: forgex_syntax_tree_error_m
+   use :: forgex_error_m
    implicit none
 
    logical :: res = .true.


### PR DESCRIPTION
This PR contains an experimental feature:
- instead of treating input characters that contain non-UTF-8 character as errors, they are replaced with U+FFFF, and the matching continues (however, only an UTF-8 string are allowed in patterns).

The implementation details of this PR are discussed in #9.

It also provides a workaround for issue of CP932 character input, which is pointed out in #6.