### PR TITLE
Unescaped curly brace#7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(src)
 set(TEST_API_DIR test/test_api)
 set(TEST_AST_DIR test/test_ast)
 set(TEST_INVALID_DIR test/test_invalid_patterns)
+set(TEST_ERR_DIR test/test_error)
 
 set(TEST_API_CASES
    test_case_001
@@ -44,6 +45,9 @@ set(TEST_INVALID_CASES
    validate_case_003
 )
 
+set(TEST_ERR_MSG_CASES
+   error_case_001
+)
 
 foreach(TEST ${TEST_API_CASES})
    add_executable(${TEST} ${TEST_API_DIR}/${TEST}.f90)
@@ -68,5 +72,14 @@ foreach(TEST ${TEST_INVALID_CASES})
    target_link_libraries(${TEST} PRIVATE forgex)
    add_test(NAME Forgex_${TEST} COMMAND ${TEST})
 endforeach()
+
+foreach(TEST ${TEST_ERR_MSG_CASES})
+   add_executable(${TEST} ${TEST_ERR_DIR}/${TEST}.f90)
+   target_sources(${TEST} PRIVATE src/test_m.f90)
+   target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
+   target_link_libraries(${TEST} PRIVATE forgex)
+   add_test(NAME Forgex_${TEST} COMMAND ${TEST})
+endforeach()
+
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
-enable_language(Fortran)
 
 project(forgex
    VERSION 4.1
    DESCRIPTION "Fortran Regular Expression"
    LANGUAGES Fortran
 )
+enable_language(Fortran)
 
 message("Project: ${PROJECT_NAME}")
 message("Description: ${PROJECT_DESCRIPTION}")

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -394,6 +394,14 @@ contains
          self%is_valid = .false.
          return
    
+      ! Unescaped closing curly brace is allowed.
+      case (tk_rcurlybrace)
+         chara = self%tape%token_char
+         seg = segment_t(ichar_utf8(chara), ichar_utf8(chara))
+         node = make_atom(seg)
+         call self%register_connector(node, terminal, terminal)
+         call self%tape%get_token()
+
       case default
          self%code = SYNTAX_ERR_THIS_SHOULD_NOT_HAPPEN
          self%is_valid = .false.

--- a/src/ast/syntax_tree_node_m.F90
+++ b/src/ast/syntax_tree_node_m.F90
@@ -191,8 +191,10 @@ contains
                self%current_token = tk_rsbracket
             case (SYMBOL_LCRB)
                self%current_token = tk_lcurlybrace
+               self%token_char = c
             case (SYMBOL_RCRB)
                self%current_token = tk_rcurlybrace
+               self%token_char = c
             case (SYMBOL_DOT)
                self%current_token = tk_dot
             case (SYMBOL_CRET)
@@ -204,6 +206,7 @@ contains
                self%token_char = c
             end select
          end if
+
 
          self%idx = next_idxutf8(self%str, ib)
 

--- a/src/forgex.F90
+++ b/src/forgex.F90
@@ -231,7 +231,7 @@ contains
    !> The function implemented for the `regex` subroutine.
    pure subroutine subroutine__regex(pattern, text, res, length, from, to, status, err_msg)
       use :: forgex_parameters_m, only: ACCEPTED_EMPTY, INVALID_CHAR_INDEX
-      use :: forgex_syntax_tree_error_m, only: get_error_message
+      use :: forgex_syntax_tree_error_m, only: get_error_message, SYNTAX_VALID
       implicit none
       character(*),              intent(in)    :: pattern, text
       character(:), allocatable, intent(inout) :: res
@@ -252,7 +252,8 @@ contains
       entirely_fixed_string = ''
       from_l = INVALID_CHAR_INDEX
       to_l = INVALID_CHAR_INDEX
-
+      if (present(status)) status = SYNTAX_VALID
+      if (present(err_msg)) err_msg = ''
       buff = trim(pattern)
 
       ! Build tree from regex pattern in the buff variable.

--- a/test/test_invalid_patterns/validate_case_002.f90
+++ b/test/test_invalid_patterns/validate_case_002.f90
@@ -33,16 +33,16 @@ program main
    
 
    call runner_validate("{", .false., res)
-   call runner_validate("}", .false., res)
+   call runner_validate("}", .true., res)
    call runner_validate("a{", .false., res)
-   call runner_validate("a}", .false., res)
+   call runner_validate("a}", .true., res)
    call runner_validate("{a", .false., res)
-   call runner_validate("}a", .false., res)
+   call runner_validate("}a", .true., res)
    call runner_validate("a{b", .false., res)
-   call runner_validate("a}b", .false., res)
+   call runner_validate("a}b", .true., res)
 
    call runner_validate("a{1,2", .false., res)
-   call runner_validate("a1,b}", .false., res)
+   call runner_validate("a1,b}", .true., res)
    call runner_validate("a{b,1}", .false., res)
    call runner_validate("a{1,b}", .false., res)
    call runner_validate("a{2,1}", .false., res)
@@ -82,6 +82,9 @@ program main
    call runner_validate("(a*)*", .true., res)
 
    call runner_validate("(\w+\s*)+", .true., res)
+   call runner_validate("\{k\}", .true., res)
+   call runner_validate("\{k}", .true., res)
+   call runner_validate("}", .true., res)
    
 !=====================================================================!
    if (res) then


### PR DESCRIPTION
This PR contains the following modification of syntax analysis:
- an unescaped RIGHT curly brace are considered as valid literal pattern `}`.

This modification is pointed out in #6 and is discussed in #7.

Note: an unescaped LEFT curly brace is still NOT accepted as a literal.