### PR TITLE
[fix] add module directory for main folder/library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,12 +12,17 @@ add_library(${STATIC_LIB} STATIC
    forgex.F90
 )
 
+set_target_properties(${STATIC_LIB} PROPERTIES
+   Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod_files
+)
+
 target_link_libraries(forgex PRIVATE essential ast nfa lazy_dfa)
 target_link_directories(forgex PRIVATE ${CMAKE_BINARY_DIR}/src/essential)
 target_link_directories(forgex PRIVATE ${CMAKE_BINARY_DIR}/src/ast)
 target_link_directories(forgex PRIVATE ${CMAKE_BINARY_DIR}/src/nfa)
 target_link_directories(forgex PRIVATE ${CMAKE_BINARY_DIR}/src/lazy_dfa)
 
+target_include_directories(forgex PUBLIC $<TARGET_PROPERTY:${STATIC_LIB},Fortran_MODULE_DIRECTORY>)
 target_include_directories(forgex PUBLIC $<TARGET_PROPERTY:essential,Fortran_MODULE_DIRECTORY>)
 target_include_directories(forgex PUBLIC $<TARGET_PROPERTY:ast,Fortran_MODULE_DIRECTORY>)
 target_include_directories(forgex PUBLIC $<TARGET_PROPERTY:nfa,Fortran_MODULE_DIRECTORY>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,8 @@ set_target_properties(${STATIC_LIB}
    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
    )
 
-install (TARGETS ${STATIC_LIB}
+install (TARGETS ${STATIC_LIB} essential ast nfa lazy_dfa
+   EXPORT "${STATIC_LIB}"
    LIBRARY DESTINATION lib
    PUBLIC_HEADER DESTINATION include
    )
@@ -46,4 +47,9 @@ install (TARGETS ${STATIC_LIB}
 install (FILES
    ${CMAKE_CURRENT_BINARY_DIR}/forgex.mod
    DESTINATION lib
+   )
+
+install (EXPORT ${STATIC_LIB}
+   NAMESPACE "${PROJECT_NAME}::"
+   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
    )


### PR DESCRIPTION
The [veggies](https://gitlab.com/everythingfunctional/veggies) library for Fortran unit tests uses forgex, but fails to compile due to missing `forgex.mod`, which is required for the `.in.` operator: [`input_test_case_m.f90:2`](https://gitlab.com/everythingfunctional/veggies/-/blob/8f1ca0586403535700594aafe3e43f5ee274c9f5/src/veggies/input_test_case_m.f90#L2)