### PR TITLE
Error handler for patterns such as '(?)'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_API_CASES
    test_case_007
    test_case_008
    test_case_009
+   test_case_010
 )
 
 set(TEST_AST_CASES
@@ -47,6 +48,7 @@ set(TEST_INVALID_CASES
 
 set(TEST_ERR_MSG_CASES
    error_case_001
+   error_case_002
 )
 
 foreach(TEST ${TEST_API_CASES})

--- a/src/ast/syntax_tree_graph_m.F90
+++ b/src/ast/syntax_tree_graph_m.F90
@@ -414,8 +414,23 @@ contains
          self%is_valid = .false.
          return
 
+      case (tk_star)
+         self%code = SYNTAX_ERR_STAR_INCOMPLETE
+         self%is_valid = .false.
+         return
+
+      case (tk_plus)
+         self%code = SYNTAX_ERR_PLUS_INCOMPLETE
+         self%is_valid = .false.
+         return
+
+      case (tk_question)
+         self%code = SYNTAX_ERR_QUESTION_INCOMPLETE
+         self%is_valid = .false.
+         return
+
       case default
-         self%code = SYNTAX_ERR_THIS_SHOULD_NOT_HAPPEN
+         self%code = SYNTAX_ERR
          self%is_valid = .false.
          return
       end select

--- a/src/essential/error_m.F90
+++ b/src/essential/error_m.F90
@@ -26,37 +26,79 @@ module forgex_error_m
       enumerator :: SYNTAX_ERR_MISPLACED_SUBTRACTION_OPERATOR
       enumerator :: SYNTAX_ERR_INVALID_CHARACTER_RANGE
       enumerator :: SYNTAX_ERR_CHAR_CLASS_SUBTRANCTION_NOT_IMPLEMENTED
-      
+      enumerator :: SYNTAX_ERR_STAR_INCOMPLETE
+      enumerator :: SYNTAX_ERR_PLUS_INCOMPLETE
+      enumerator :: SYNTAX_ERR_QUESTION_INCOMPLETE
       enumerator :: SYNTAX_ERR_THIS_SHOULD_NOT_HAPPEN
-      
-      
+            
       enumerator :: ALLOCATION_ERR
+
    end enum
 
 
    ! Error message lines.
+   ! SYNTAX_VALID
    character(*), parameter :: err_is_nothing    = "Given pattern is valid."
-   character(*), parameter :: err_generic                  = "ERROR: Pattern includes some syntax error."
-   character(*), parameter :: err_r_parenthesis_missing    = "ERROR: Closing parenthesis is expected."
+   
+   ! SYNTAX_ERR
+   character(*), parameter :: err_generic = "ERROR: Pattern includes some syntax error."
+   
+   ! SYNTAX_ERR_PARENTHESIS_MISSING
+   character(*), parameter :: err_r_parenthesis_missing = "ERROR: Closing parenthesis is expected."
+   
+   ! SYNTAX_ERR_PARENTHESIS_UNEXPECTED
    character(*), parameter :: err_r_parenthesis_unexpected = "ERROR: Unexpected closing parenthesis error."
-   character(*), parameter :: err_r_bracket_missing        = "ERROR: Closing square bracket is expected."
-   character(*), parameter :: err_r_bracket_unexpected     = "ERROR: Unexpected closing square bracket error."
-   character(*), parameter :: err_r_curlybrace_missing     = "ERROR: Closing right curlybrace is expected."
-   character(*), parameter :: err_r_curlybrace_unexpected  = "ERROR: Unexpected closing right curlybrace error."
-   character(*), parameter :: err_invalid_quantifier       = "ERROR: Given quantifier range is invalid."
-   character(*), parameter :: err_escaped_symbol_missing   = "ERROR: Pattern cannot end with a trailing unescaped backslash."
-   character(*), parameter :: err_escaped_symbol_invalid   = "ERROR: This token has no special meaning."
-   character(*), parameter :: err_empty_character_class    = "ERROR: Given class has no character."
+   
+   ! SYNTAX_ERR_BRACKET_MISSING
+   character(*), parameter :: err_r_bracket_missing = "ERROR: Closing square bracket is expected."
+   
+   ! SYNTAX_ERR_BRACKET_UNEXPECTED
+   character(*), parameter :: err_r_bracket_unexpected = "ERROR: Unexpected closing square bracket error."
+   
+   ! SYNTAX_ERR_CURLYBRACE_MISSING
+   character(*), parameter :: err_r_curlybrace_missing = "ERROR: Closing right curlybrace is expected."
+   
+   ! SYNTAX_ERR_CURLYBRACE_UNEXPECTED
+   character(*), parameter :: err_r_curlybrace_unexpected = "ERROR: Unexpected closing right curlybrace error."
+   
+   ! SYNTAX_ERR_INVALID_TIMES
+   character(*), parameter :: err_invalid_quantifier = "ERROR: Given quantifier range is invalid."
+   
+   ! SYNTAX_ERR_ESCAPED_SYMBOL_MISSING
+   character(*), parameter :: err_escaped_symbol_missing = "ERROR: Pattern cannot end with a trailing unescaped backslash."
+   
+   ! SYNTAX_ERR_ESCAPED_SYMBOL_INVALID
+   character(*), parameter :: err_escaped_symbol_invalid = "ERROR: This token has no special meaning."
+   
+   ! SYNTAX_ERR_EMPTY_CHARACTER_CLASS
+   character(*), parameter :: err_empty_character_class = "ERROR: Given class has no character."
+   
+   ! SYNTAX_ERR_RANGE_WITH_ESCAPE_SEQUENCES
    character(*), parameter :: err_range_with_escape_sequences = "ERROR: Cannot create a range with shorthand escape sequence"
+   
+   ! SYNTAX_ERR_MISPLACED_SUBTRACTION_OPERATOR
    character(*), parameter :: err_misplaced_subtraction_operator &
                                                   = "ERROR: Subtraction operator is misplaced in the given character class."
-   character(*), parameter :: err_invalid_character_range  = "ERROR: Given character range is invalid."
+   ! SYNTAX_ERR_INVALID_CHARACTER_RANGE
+   character(*), parameter :: err_invalid_character_range = "ERROR: Given character range is invalid."
+   
+   ! SYNTAX_ERR_CHAR_CLASS_SUBTRANCTION_NOT_IMPLEMENTED
    character(*), parameter :: err_character_class_subtraction = "ERROR: Character class subtraction hasn't implemented yet."
-
-   character(*), parameter :: err_allocation               = "ERROR: Allocation is failed."
    
-   character(*), parameter :: err_this_should_not_happen   = "ERROR: Fatal error is happened."
+   ! SYNTAX_ERR_STAR_INCOMPLETE
+   character(*), parameter :: err_star_incomplete = "ERROR: Not quantifiable; star '*' operator is missing operand."
    
+   ! SYNTAX_ERR_PLUS_INCOMPLETE
+   character(*), parameter :: err_plus_incomplete = "ERROR: Not quantifiable; plus '+' operator is missing operand."
+   
+   ! SYNTAX_ERR_QUESTION_INCOMPLETE
+   character(*), parameter :: err_question_incomplete = "ERROR: Not quantifiable; question '?' operator is missing operand."
+   
+   ! SYNTAX_ERR_THIS_SHOULD_NOT_HAPPEN
+   character(*), parameter :: err_this_should_not_happen = "ERROR: Fatal error is happened."
+   
+   ! ALLOCATION_ERR
+   character(*), parameter :: err_allocation = "ERROR: Allocation is failed."
 
 
 contains
@@ -71,9 +113,10 @@ contains
       select case (code)
       case (SYNTAX_VALID)
          msg = err_is_nothing
-   
+
       case (SYNTAX_ERR)
          msg = err_generic
+
       case (SYNTAX_ERR_PARENTHESIS_MISSING)
          msg = err_r_parenthesis_missing
 
@@ -116,6 +159,15 @@ contains
       case (SYNTAX_ERR_CHAR_CLASS_SUBTRANCTION_NOT_IMPLEMENTED)
          msg = err_character_class_subtraction
       
+      case (SYNTAX_ERR_STAR_INCOMPLETE)
+         msg = err_star_incomplete
+      
+      case (SYNTAX_ERR_PLUS_INCOMPLETE)
+         msg = err_plus_incomplete
+      
+      case (SYNTAX_ERR_QUESTION_INCOMPLETE)
+         msg = err_question_incomplete
+
       case (ALLOCATION_ERR)
          msg = err_allocation
 

--- a/test/test_error/error_case_001.f90
+++ b/test/test_error/error_case_001.f90
@@ -40,6 +40,10 @@ program error_case_001
    call runner_error("\a", "", SYNTAX_ERR_ESCAPED_SYMBOL_INVALID, res)
    call runner_error("\\\", "", SYNTAX_ERR_ESCAPED_SYMBOL_MISSING, res)
 
+   call runner_error("\{\}", "", SYNTAX_VALID, res)
+   call runner_error("\{}", "", SYNTAX_VALID, res)
+
+
 !=====================================================================!
    if (res) then
       write(error_unit, *) "=== ERROR MESSAGE CASE 1 END ==="

--- a/test/test_error/error_case_002.f90
+++ b/test/test_error/error_case_002.f90
@@ -1,0 +1,109 @@
+program error_case_001
+   use :: iso_fortran_env
+   use :: forgex_test_m
+   use :: forgex_error_m
+   implicit none
+
+   logical :: res = .true.
+
+   ! For handling errors of the special tokens.
+   ! Pointed out in issue#6 on GitHub.
+
+   print *, "=== ERROR MESSAGE CASE 2 BEGIN ==="
+!=====================================================================!
+
+   call runner_error('|', '', SYNTAX_VALID, res)
+   call runner_error(')', '', SYNTAX_ERR_PARENTHESIS_UNEXPECTED, res)
+   call runner_error('*', '', SYNTAX_ERR_STAR_INCOMPLETE, res)
+   call runner_error('+', '', SYNTAX_ERR_PLUS_INCOMPLETE, res)
+   call runner_error('?', '', SYNTAX_ERR_QUESTION_INCOMPLETE, res)
+   call runner_error('\', '', SYNTAX_ERR_ESCAPED_SYMBOL_MISSING, res)
+   call runner_error('{', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('}', '', SYNTAX_VALID, res)
+   call runner_error('$', '', SYNTAX_VALID, res)
+   call runner_error('^', '', SYNTAX_VALID, res)
+   call runner_error('.', '', SYNTAX_VALID, res)
+   call runner_error('-', '', SYNTAX_VALID, res)
+
+   call runner_error('||', '', SYNTAX_VALID, res)
+   call runner_error('))', '', SYNTAX_ERR_PARENTHESIS_UNEXPECTED, res)
+   call runner_error('**', '', SYNTAX_ERR_STAR_INCOMPLETE, res)
+   call runner_error('++', '', SYNTAX_ERR_PLUS_INCOMPLETE, res)
+   call runner_error('??', '', SYNTAX_ERR_QUESTION_INCOMPLETE, res)
+   call runner_error('\\', '', SYNTAX_VALID, res)
+   call runner_error('{{', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('}}', '', SYNTAX_VALID, res)
+   call runner_error('$$', '', SYNTAX_VALID, res)
+   call runner_error('^^', '', SYNTAX_VALID, res)
+   call runner_error('..', '', SYNTAX_VALID, res)
+   call runner_error('--', '', SYNTAX_VALID, res)
+
+   call runner_error('(|)', '', SYNTAX_VALID, res)
+   call runner_error('())', '', SYNTAX_ERR_PARENTHESIS_UNEXPECTED, res)
+   call runner_error('(*)', '', SYNTAX_ERR_STAR_INCOMPLETE, res)
+   call runner_error('(+)', '', SYNTAX_ERR_PLUS_INCOMPLETE, res)
+   call runner_error('(?)', '', SYNTAX_ERR_QUESTION_INCOMPLETE, res)
+   call runner_error('(\)', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('({)', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('(})', '', SYNTAX_VALID, res)
+   call runner_error('($)', '', SYNTAX_VALID, res)
+   call runner_error('(^)', '', SYNTAX_VALID, res)
+   call runner_error('(.)', '', SYNTAX_VALID, res)
+   call runner_error('(-)', '', SYNTAX_VALID, res)
+
+   call runner_error('(||', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('())', '', SYNTAX_ERR_PARENTHESIS_UNEXPECTED, res)
+   call runner_error('(**', '', SYNTAX_ERR_STAR_INCOMPLETE, res)
+   call runner_error('(++', '', SYNTAX_ERR_PLUS_INCOMPLETE, res)
+   call runner_error('(??', '', SYNTAX_ERR_QUESTION_INCOMPLETE, res)
+   call runner_error('(\\', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('({{', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('(}}', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('($$', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('(^^', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('(..', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('(--', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+
+   call runner_error('(||)', '', SYNTAX_VALID, res)
+   call runner_error('(\\)', '', SYNTAX_VALID, res)
+   call runner_error('(}})', '', SYNTAX_VALID, res)
+   call runner_error('($$)', '', SYNTAX_VALID, res)
+   call runner_error('(^^)', '', SYNTAX_VALID, res)
+   call runner_error('(..)', '', SYNTAX_VALID, res)
+   call runner_error('(--)', '', SYNTAX_VALID, res)
+
+   call runner_error('[|]', '', SYNTAX_VALID, res)
+   call runner_error('[)]', '', SYNTAX_VALID, res)
+   call runner_error('[*]', '', SYNTAX_VALID, res)
+   call runner_error('[+]', '', SYNTAX_VALID, res)
+   call runner_error('[?]', '', SYNTAX_VALID, res)
+   call runner_error('[\]', '', SYNTAX_ERR_BRACKET_MISSING, res)
+   call runner_error('[{]', '', SYNTAX_VALID, res)
+   call runner_error('[}]', '', SYNTAX_VALID, res)
+   call runner_error('[$]', '', SYNTAX_VALID, res)
+   call runner_error('[^]', '', SYNTAX_ERR_EMPTY_CHARACTER_CLASS, res)
+   call runner_error('[.]', '', SYNTAX_VALID, res)
+   call runner_error('[-]', '', SYNTAX_VALID, res)
+
+   call runner_error('{|}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{)}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{*}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{+}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{?}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{\}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{{}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{}}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{$}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{^}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{.}', '', SYNTAX_ERR_INVALID_TIMES, res)
+   call runner_error('{-}', '', SYNTAX_ERR_INVALID_TIMES, res)
+
+!=====================================================================!
+   if (res) then
+      write(error_unit, *) "=== ERROR MESSAGE CASE 2 END ==="
+      stop
+   else
+      error stop
+   end if
+   
+end program error_case_001

--- a/test/test_error/error_case_002.f90
+++ b/test/test_error/error_case_002.f90
@@ -43,7 +43,7 @@ program error_case_001
    call runner_error('(*)', '', SYNTAX_ERR_STAR_INCOMPLETE, res)
    call runner_error('(+)', '', SYNTAX_ERR_PLUS_INCOMPLETE, res)
    call runner_error('(?)', '', SYNTAX_ERR_QUESTION_INCOMPLETE, res)
-   call runner_error('(\)', '', SYNTAX_ERR_PARENTHESIS_MISSING, res)
+   call runner_error('(\)', '', SYNTAX_ERR_PARENTHESIS_MISSING, res) ! \) means escaped right-parenthesis by backslash
    call runner_error('({)', '', SYNTAX_ERR_INVALID_TIMES, res)
    call runner_error('(})', '', SYNTAX_VALID, res)
    call runner_error('($)', '', SYNTAX_VALID, res)


### PR DESCRIPTION
- **[fix] primary error handler is fixed, pointed out in the issue #6**
- **[add] error_case_002 added in CMakeLists.txt.**

This PR includes fixes for the error message of invalid patterns, such as `(?`, `(+)`, `(*)`.