### PR TITLE
gh-24: Add FORGEX_BUILD_TESTING cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,77 +16,80 @@ add_subdirectory(src)
 
 
 ### TESTS settings 
+option(FORGEX_BUILD_TESTING "Enable testing for this project" ON)
 
-set(TEST_API_DIR test/test_api)
-set(TEST_AST_DIR test/test_ast)
-set(TEST_INVALID_DIR test/test_invalid_patterns)
-set(TEST_ERR_DIR test/test_error)
+if(FORGEX_BUILD_TESTING)
+   set(TEST_API_DIR test/test_api)
+   set(TEST_AST_DIR test/test_ast)
+   set(TEST_INVALID_DIR test/test_invalid_patterns)
+   set(TEST_ERR_DIR test/test_error)
 
-set(TEST_API_CASES
-   test_case_001
-   test_case_002
-   test_case_003
-   test_case_004
-   test_case_005
-   test_case_006
-   test_case_007
-   test_case_008
-   test_case_009
-   test_case_010
-   test_case_011
-   test_case_012
-   test_case_013
-   test_case_014
-)
+   set(TEST_API_CASES
+      test_case_001
+      test_case_002
+      test_case_003
+      test_case_004
+      test_case_005
+      test_case_006
+      test_case_007
+      test_case_008
+      test_case_009
+      test_case_010
+      test_case_011
+      test_case_012
+      test_case_013
+      test_case_014
+   )
 
-set(TEST_AST_CASES
-   ast_case_001
-   ast_case_002
-)
+   set(TEST_AST_CASES
+      ast_case_001
+      ast_case_002
+   )
 
-set(TEST_INVALID_CASES
-   validate_case_001
-   validate_case_002
-   validate_case_003
-)
+   set(TEST_INVALID_CASES
+      validate_case_001
+      validate_case_002
+      validate_case_003
+   )
 
-set(TEST_ERR_MSG_CASES
-   error_case_001
-   error_case_002
-   error_case_003
-)
+   set(TEST_ERR_MSG_CASES
+      error_case_001
+      error_case_002
+      error_case_003
+   )
 
-foreach(TEST ${TEST_API_CASES})
-   add_executable(${TEST} ${TEST_API_DIR}/${TEST}.f90)
-   target_sources(${TEST} PRIVATE src/test_m.F90)
-   target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
-   target_link_libraries(${TEST} PRIVATE forgex)
-   add_test(NAME Forgex_${TEST} COMMAND ${TEST})
-endforeach()
+   foreach(TEST ${TEST_API_CASES})
+      add_executable(${TEST} ${TEST_API_DIR}/${TEST}.f90)
+      target_sources(${TEST} PRIVATE src/test_m.F90)
+      target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
+      target_link_libraries(${TEST} PRIVATE forgex)
+      add_test(NAME Forgex_${TEST} COMMAND ${TEST})
+   endforeach()
 
-foreach(TEST ${TEST_AST_CASES})
-   add_executable(${TEST} ${TEST_AST_DIR}/${TEST}.f90)
-   target_sources(${TEST} PRIVATE src/test_m.F90)
-   target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
-   target_link_libraries(${TEST} PRIVATE forgex)
-   add_test(NAME Forgex_${TEST} COMMAND ${TEST})
-endforeach()
+   foreach(TEST ${TEST_AST_CASES})
+      add_executable(${TEST} ${TEST_AST_DIR}/${TEST}.f90)
+      target_sources(${TEST} PRIVATE src/test_m.F90)
+      target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
+      target_link_libraries(${TEST} PRIVATE forgex)
+      add_test(NAME Forgex_${TEST} COMMAND ${TEST})
+   endforeach()
 
-foreach(TEST ${TEST_INVALID_CASES})
-   add_executable(${TEST} ${TEST_INVALID_DIR}/${TEST}.f90)
-   target_sources(${TEST} PRIVATE src/test_m.F90)
-   target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
-   target_link_libraries(${TEST} PRIVATE forgex)
-   add_test(NAME Forgex_${TEST} COMMAND ${TEST})
-endforeach()
+   foreach(TEST ${TEST_INVALID_CASES})
+      add_executable(${TEST} ${TEST_INVALID_DIR}/${TEST}.f90)
+      target_sources(${TEST} PRIVATE src/test_m.F90)
+      target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
+      target_link_libraries(${TEST} PRIVATE forgex)
+      add_test(NAME Forgex_${TEST} COMMAND ${TEST})
+   endforeach()
 
-foreach(TEST ${TEST_ERR_MSG_CASES})
-   add_executable(${TEST} ${TEST_ERR_DIR}/${TEST}.f90)
-   target_sources(${TEST} PRIVATE src/test_m.F90)
-   target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
-   target_link_libraries(${TEST} PRIVATE forgex)
-   add_test(NAME Forgex_${TEST} COMMAND ${TEST})
-endforeach()
+   foreach(TEST ${TEST_ERR_MSG_CASES})
+      add_executable(${TEST} ${TEST_ERR_DIR}/${TEST}.f90)
+      target_sources(${TEST} PRIVATE src/test_m.F90)
+      target_include_directories(${TEST} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
+      target_link_libraries(${TEST} PRIVATE forgex)
+      add_test(NAME Forgex_${TEST} COMMAND ${TEST})
+   endforeach()
 
 
-enable_testing()
+   enable_testing()
+endif()


### PR DESCRIPTION
Adds an option `FORGEX_BUILD_TESTING` which is ON by default but disables building the tests if set to OFF.

`FORGEX_BUILD_TESTING` can be set via the CLI

```bash
cmake -B build -DFORGEX_BUILD_TESTING=<OFF|ON>
```

or from within a CMakeLists.txt via
```cmake
set(FORGEX_BUILD_TESTING OFF CACHE BOOL "Disable forgex internal tests")
```

closes #24